### PR TITLE
Ensure client auto-discovers server

### DIFF
--- a/server.cpp
+++ b/server.cpp
@@ -51,7 +51,7 @@
 HINSTANCE g_hInstance = nullptr;
 HWND g_hMainWnd = nullptr;
 HWND g_hClientList = nullptr;
-int g_serverPort = 8080;
+int g_serverPort = 443;
 std::thread* g_serverThread = nullptr;
 std::mutex g_clientsMutex;
 


### PR DESCRIPTION
## Summary
- Default both client and server to port 443 so discovery uses the standard HTTPS port
- Leave client host unset so it relies on local subnet scanning, including 192.168.88.0/24

## Testing
- `make client CXX=x86_64-w64-mingw32-g++ OS=Windows_NT`
- `make server CXX=x86_64-w64-mingw32-g++ OS=Windows_NT`
- `wine server.exe` *(fails: Application tried to create a window, but no driver could be loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa7300cf883219b6109ea523dcf74